### PR TITLE
Use mu4e-mu-binary instead of relying on PATH

### DIFF
--- a/mu4e-jump-to-list.el
+++ b/mu4e-jump-to-list.el
@@ -83,7 +83,7 @@ The string should be a valid mu4e query to select messages eligible for
 		   "| sort -n -k2 | awk '{ if($1 > %d) print $3 }'")
 	   mu4e-jump-to-list-min-freq))
 	 (command
-	  (concat "mu find -s date -z -f v " quoted filter)))
+	  (concat mu4e-mu-binary " find -s date -z -f v " quoted filter)))
     (split-string (shell-command-to-string command) "\n" t)))
 
 (defun mu4e-jump-to-list--kill-lists (lists)


### PR DESCRIPTION
Fix the scenario where the user is running mu from a custom location
using mu4e-mu-binary.